### PR TITLE
feat: Add button to delete discount index

### DIFF
--- a/app/controllers/discounts_controller.rb
+++ b/app/controllers/discounts_controller.rb
@@ -1,5 +1,5 @@
 class DiscountsController < ApplicationController
-  before_action :find_discount_and_merchant, only: [:show]
+  before_action :find_discount_and_merchant, only: [:show, :destroy]
   before_action :find_merchant, only: [:new, :index, :create]
 
   def index
@@ -23,6 +23,11 @@ class DiscountsController < ApplicationController
       flash.notice = "That's Not Quite Right! Try Again, if you wish!"
       redirect_to new_merchant_discount_path(@merchant)
     end
+  end
+
+  def destroy
+    @discount.destroy
+    redirect_to merchant_discounts_path(@merchant)
   end
 
   private

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -21,7 +21,7 @@
       </ul>
       <ul class='mr-auto col-sm-4'>
         <% @invoices.each do |i| %>
-          <li><%= link_to "Invoice # #{i.id}", admin_invoice_path(i.id) %></a> - <%= i.created_at.strftime("%A, %B %d, %Y") %>
+          <li><%= link_to "Invoice # #{i.id}", admin_invoice_path(i.id) %> - <%= i.created_at.strftime("%A, %B %d, %Y") %>
         <% end %>
       </ul>
   </div>

--- a/app/views/discounts/index.html.erb
+++ b/app/views/discounts/index.html.erb
@@ -7,13 +7,17 @@
 
   <p><%= link_to "Create New Discount", new_merchant_discount_path(@merchant) %></p>
 
-  <ul>
+  <ul class='ml-auto col-sm-4'>
     <% @discounts.each do |discount| %>
-      <div id="discount-<%= discount.id %>">
-        <ul><%= link_to "Discount ##{discount.id}", merchant_discount_path(@merchant, discount) %>
-          <li><%= discount.percent.to_i %>% Off </li>
-          <li>Quantity of <%= discount.threshold %> or more</li>
-        </ul>
+      <div class="row">
+        <div id="discount-<%= discount.id %>">
+          <ul><%= link_to "Discount ##{discount.id}", merchant_discount_path(@merchant, discount) %>
+            <li><%= button_to 'Delete', merchant_discount_path(@merchant, discount), method: :delete, local: true %>
+            <%= link_to 'Edit'%>
+            <li><%= discount.percent.to_i %>% Off </li>
+            <li>Quantity of <%= discount.threshold %> or more</li>
+          </ul>
+        </div>
       </div>
       <br>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :discounts, only: [:index, :show, :new, :create]
+    resources :discounts, only: [:index, :show, :new, :create, :destroy]
   end
   
 

--- a/spec/features/discounts/index_spec.rb
+++ b/spec/features/discounts/index_spec.rb
@@ -65,5 +65,31 @@ describe "merchant discounts index" do
         expect(current_path).to eq(new_merchant_discount_path(@merchant2))
       end
     end
+
+    describe "button to delete bulk discount" do
+      it "has button next to each discount to delete when clicked and redirect to index page" do
+        within "#discount-#{@discount1.id}" do 
+          expect(page).to have_button("Delete")
+          click_on("Delete")
+          expect(current_path).to eq(merchant_discounts_path(@merchant1))
+        end
+        expect(page).to_not have_content(@discount1.id)
+
+        visit merchant_discounts_path(@merchant1)
+        within "#discount-#{@discount2.id}" do 
+          expect(page).to have_button("Delete")
+          click_on("Delete")
+          expect(current_path).to eq(merchant_discounts_path(@merchant1))
+        end
+        expect(page).to_not have_content(@discount2.id)
+        visit merchant_discounts_path(@merchant1)
+        within "#discount-#{@discount3.id}" do 
+          expect(page).to have_button("Delete")
+          click_on("Delete")
+          expect(current_path).to eq(merchant_discounts_path(@merchant1))
+        end
+        expect(page).to_not have_content(@discount3.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
As a merchant

- [x]  When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
- [x]  When I click this link
Then I am redirected back to the bulk discounts index page
- [x]  And I no longer see the discount listed