### PR TITLE
feat: Display discount info on show

### DIFF
--- a/app/views/discounts/index.html.erb
+++ b/app/views/discounts/index.html.erb
@@ -2,7 +2,7 @@
 
 <body>
   <div class="row">
-    <p class='col-12'>My Discounts</p>
+    <p class='col-12'>My Bulk Discounts</p>
   </div>
 
   <p><%= link_to "Create New Discount", new_merchant_discount_path(@merchant) %></p>

--- a/app/views/discounts/show.html.erb
+++ b/app/views/discounts/show.html.erb
@@ -1,1 +1,11 @@
 <%= render "shared/menu" %>
+
+<body>
+  <div class="row">
+    <p class='col-12'>Bulk Discount #<%= @discount.id %></p>
+  </div>
+
+  <p>Quantity Threshold: <b><%= @discount.threshold %></b></p>
+  <p>Percentage Discount: <b><%= @discount.percent %>%</b></p>
+  <p></p>
+</body>

--- a/spec/features/discounts/show_spec.rb
+++ b/spec/features/discounts/show_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "Bulk Discount Show Page" do
+  before :each do 
+    disc_feat_spec
+  end
+
+  describe "When I visit the Bulk Discount show page" do
+    it "displays that discount's threshold and percent discount" do
+      visit merchant_discount_path(@merchant1, @discount1)
+      expect(page).to have_content("Bulk Discount ##{@discount1.id}")
+      expect(page).to_not have_content("Bulk Discount ##{@discount2.id}")
+      expect(page).to_not have_content("Bulk Discount ##{@discount3.id}")
+      expect(page).to have_content("Quantity Threshold: 6")
+      expect(page).to have_content("Percentage Discount: 10.0%")
+
+      visit merchant_discount_path(@merchant2, @discount5)
+      expect(page).to have_content("Bulk Discount ##{@discount5.id}")
+      expect(page).to_not have_content("Bulk Discount ##{@discount4.id}")
+      expect(page).to have_content("Quantity Threshold: 25")
+      expect(page).to have_content("Percentage Discount: 25.0%")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ def disc_feat_spec
 
   @merchant2 = Merchant.create!(name: 'Iron Lak')
   @discount4 = @merchant2.discounts.create!(percent: 15, threshold: 10)
+  @discount5 = @merchant2.discounts.create!(percent: 25, threshold: 25)
 end
 # Given that it is always loaded, you are encouraged to keep this file as
 # light-weight as possible. Requiring heavyweight dependencies from this file


### PR DESCRIPTION
As a merchant
- [x] When I visit my bulk discount show page
- [x] Then I see the bulk discount's quantity threshold and percentage discount