### PR TITLE
#5 merchant bulk discount edit

### DIFF
--- a/app/controllers/discounts_controller.rb
+++ b/app/controllers/discounts_controller.rb
@@ -1,5 +1,5 @@
 class DiscountsController < ApplicationController
-  before_action :find_discount_and_merchant, only: [:show, :destroy, :edit]
+  before_action :find_discount_and_merchant, only: [:show, :destroy, :edit, :update]
   before_action :find_merchant, only: [:new, :index, :create]
 
   def index
@@ -12,6 +12,12 @@ class DiscountsController < ApplicationController
   def edit
   end
   
+  def update
+    @discount.update(discount_params)
+    flash.notice = "Discount Updated! Nice!"
+    redirect_to merchant_discount_path(@merchant, @discount)
+  end
+
   def new
   end
 
@@ -34,6 +40,10 @@ class DiscountsController < ApplicationController
   end
 
   private
+  def discount_params
+    params.require(:discount).permit(:percent, :threshold)
+  end
+
   def find_discount_and_merchant
     @discount = Discount.find(params[:id])
     @merchant = Merchant.find(params[:merchant_id])

--- a/app/controllers/discounts_controller.rb
+++ b/app/controllers/discounts_controller.rb
@@ -1,5 +1,5 @@
 class DiscountsController < ApplicationController
-  before_action :find_discount_and_merchant, only: [:show, :destroy]
+  before_action :find_discount_and_merchant, only: [:show, :destroy, :edit]
   before_action :find_merchant, only: [:new, :index, :create]
 
   def index
@@ -9,6 +9,9 @@ class DiscountsController < ApplicationController
   def show
   end
 
+  def edit
+  end
+  
   def new
   end
 

--- a/app/views/discounts/edit.html.erb
+++ b/app/views/discounts/edit.html.erb
@@ -1,0 +1,16 @@
+<%= render "shared/menu" %>
+
+<body>
+  <div class="row">
+    <p class='col-12'>Edit Discount #<%= @discount.id %></p>
+  </div>
+
+  <%= form_with model: @discount, method: :patch, url: merchant_discount_path(@merchant, @discount), local: true do |f| %>
+    <%= f.label :percent, "Percent" %>
+    <%= f.number_field :percent, in: 1..99 %>
+    <%= f.label :threshold, "Threshold" %>
+    <%= f.number_field :threshold, in: 1..99 %>
+    <%= f.submit "Update #{@discount.id}" %>
+  <% end %>
+
+</body>

--- a/app/views/discounts/index.html.erb
+++ b/app/views/discounts/index.html.erb
@@ -13,7 +13,6 @@
         <div id="discount-<%= discount.id %>">
           <ul><%= link_to "Discount ##{discount.id}", merchant_discount_path(@merchant, discount) %>
             <li><%= button_to 'Delete', merchant_discount_path(@merchant, discount), method: :delete, local: true %>
-            <%= link_to 'Edit'%>
             <li><%= discount.percent.to_i %>% Off </li>
             <li>Quantity of <%= discount.threshold %> or more</li>
           </ul>

--- a/app/views/discounts/show.html.erb
+++ b/app/views/discounts/show.html.erb
@@ -7,5 +7,5 @@
 
   <p>Quantity Threshold: <b><%= @discount.threshold %></b></p>
   <p>Percentage Discount: <b><%= @discount.percent %>%</b></p>
-  <p></p>
+  <p><%= link_to "Edit #{@discount.id}", edit_merchant_discount_path(@merchant, @discount), class: 'link_1', style: 'pull-right' %></p>
 </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :discounts, only: [:index, :show, :new, :create, :destroy, :edit]
+    resources :discounts
   end
   
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :discounts, only: [:index, :show, :new, :create, :destroy]
+    resources :discounts, only: [:index, :show, :new, :create, :destroy, :edit]
   end
   
 

--- a/spec/features/discounts/edit_spec.rb
+++ b/spec/features/discounts/edit_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe "Bulk Discount Edit Page" do
+  before :each do
+    disc_feat_spec
+    visit edit_merchant_discount_path(@merchant2, @discount5)
+  end
+
+  describe "has a form to edit bulk discount" do
+    it "the discount's current attributes are pre-populated in the form" do
+      expect(page).to have_field("Percent")
+      expect(page).to have_field("Threshold")
+      expect(find_field("Percent").value).to eq("#{@discount5.percent}")
+      expect(find_field("Threshold").value).to eq("#{@discount5.threshold}")
+      expect(page).to have_button("Update #{@discount5.id}")
+    
+      visit edit_merchant_discount_path(@merchant1, @discount3)
+      expect(page).to have_field("Percent")
+      expect(page).to have_field("Threshold")
+      expect(find_field("Percent").value).to eq("#{@discount3.percent}")
+      expect(find_field("Threshold").value).to eq("#{@discount3.threshold}")
+      expect(page).to have_button("Update #{@discount3.id}")
+    end
+
+    it "change any/all of the info, submit, and be redirected to show page where updated attributes are displayed" do
+      click_on "Update #{@discount5.id}"
+      expect(current_path).to eq(merchant_discount_path(@merchant2, @discount5))
+      expect(page).to have_content("Discount Updated! Nice!")
+      expect(page).to have_content("Quantity Threshold: 25")
+      expect(page).to have_content("Percentage Discount: 25.0%")
+
+      visit edit_merchant_discount_path(@merchant2, @discount5)
+      fill_in "Percent", with: 20
+      click_on "Update #{@discount5.id}"
+
+      expect(current_path).to eq(merchant_discount_path(@merchant2, @discount5))
+      expect(page).to have_content("Discount Updated! Nice!")
+      expect(page).to have_content("Quantity Threshold: 25")
+      expect(page).to have_content("Percentage Discount: 20.0%")
+
+      visit edit_merchant_discount_path(@merchant2, @discount5)
+      fill_in "Percent", with: 40
+      fill_in "Threshold", with: 40
+      click_on "Update #{@discount5.id}"
+
+      expect(current_path).to eq(merchant_discount_path(@merchant2, @discount5))
+      expect(page).to have_content("Discount Updated! Nice!")
+      expect(page).to have_content("Quantity Threshold: 40")
+      expect(page).to have_content("Percentage Discount: 40.0%")
+    end
+  end
+end

--- a/spec/features/discounts/show_spec.rb
+++ b/spec/features/discounts/show_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe "Bulk Discount Show Page" do
   before :each do 
     disc_feat_spec
+    visit merchant_discount_path(@merchant1, @discount1)
   end
 
   describe "When I visit the Bulk Discount show page" do
     it "displays that discount's threshold and percent discount" do
-      visit merchant_discount_path(@merchant1, @discount1)
       expect(page).to have_content("Bulk Discount ##{@discount1.id}")
       expect(page).to_not have_content("Bulk Discount ##{@discount2.id}")
       expect(page).to_not have_content("Bulk Discount ##{@discount3.id}")
@@ -19,6 +19,17 @@ RSpec.describe "Bulk Discount Show Page" do
       expect(page).to_not have_content("Bulk Discount ##{@discount4.id}")
       expect(page).to have_content("Quantity Threshold: 25")
       expect(page).to have_content("Percentage Discount: 25.0%")
+    end
+
+    it "has link to a new page to edit the bulk discount" do
+      expect(page).to have_link("Edit #{@discount1.id}")
+      click_link("Edit #{@discount1.id}")
+      expect(current_path).to eq(edit_merchant_discount_path(@merchant1, @discount1))
+
+      visit merchant_discount_path(@merchant2, @discount5)
+      expect(page).to have_link("Edit #{@discount5.id}")
+      click_link("Edit #{@discount5.id}")
+      expect(current_path).to eq(edit_merchant_discount_path(@merchant2, @discount5))
     end
   end
 end


### PR DESCRIPTION
As a merchant
When I visit my bulk discount show page

- [x]  Then I see a link to edit the bulk discount

- [x]  When I click this link
Then I am taken to a new page with a form to edit the discount

- [x]  And I see that the discounts current attributes are pre-populated in the form

- [x]  When I change any/all of the information and click submit
- [x] Then I am redirected to the bulk discount's show page

- [x]  And I see that the discount's attributes have been updated